### PR TITLE
Use https instead of git protocol

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "async": "^1.3.0",
     "bitcoind-rpc": "^0.6.0",
-    "bitcore-lib-komodo": "git+ssh://git@github.com:supernetorg/bitcore-lib-komodo",
+    "bitcore-lib-komodo": "https://github.com/supernetorg/bitcore-lib-komodo",
     "body-parser": "^1.13.3",
     "colors": "^1.1.2",
     "commander": "^2.8.1",


### PR DESCRIPTION
Easier to use with docker and servers that dont have deploy keys etc.